### PR TITLE
Adds support for changing delims through params when using processor with postcss.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,8 @@
 import postcss from 'postcss';
 
-const modDelim = process.env.REBEM_MOD_DELIM || '_';
-const elemDelim = process.env.REBEM_ELEM_DELIM || '__';
-
-export default postcss.plugin('rebem-css', (elemDelim = elemDelim, modDelim = modDelim) => (css) => {
+export default postcss.plugin('rebem-css', 
+    (elemDelim = process.env.REBEM_ELEM_DELIM || '__', modDelim = process.env.REBEM_MOD_DELIM || '_') =>
+    (css) => {
     css.walkRules((rule) => {
         rule.selector = rule.selector
             // :block(block) → .block

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ import postcss from 'postcss';
 const modDelim = process.env.REBEM_MOD_DELIM || '_';
 const elemDelim = process.env.REBEM_ELEM_DELIM || '__';
 
-export default postcss.plugin('rebem-css', () => (css) => {
+export default postcss.plugin('rebem-css', (elemDelim = elemDelim, modDelim = modDelim) => (css) => {
     css.walkRules((rule) => {
         rule.selector = rule.selector
             // :block(block) → .block

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,11 @@
 import postcss from 'postcss';
 
-export default postcss.plugin('rebem-css', 
-    (elemDelim = process.env.REBEM_ELEM_DELIM || '__', modDelim = process.env.REBEM_MOD_DELIM || '_') =>
+export default postcss.plugin('rebem-css',
+    (elemDelim = process.env.REBEM_ELEM_DELIM
+        || '__', modDelim = process.env.REBEM_MOD_DELIM || '_') =>
     (css) => {
-    css.walkRules((rule) => {
-        rule.selector = rule.selector
+        css.walkRules((rule) => {
+            rule.selector = rule.selector
             // :block(block) → .block
             .replace(/:block\(([\w-]+)\)/g, '.$1')
             // :elem(elem) → __elem
@@ -18,5 +19,5 @@ export default postcss.plugin('rebem-css',
 
                 return modDelim + mod;
             });
+        });
     });
-});

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 import postcss from 'postcss';
 
 export default postcss.plugin('rebem-css',
-    (elemDelim = process.env.REBEM_ELEM_DELIM
-        || '__', modDelim = process.env.REBEM_MOD_DELIM || '_') =>
+    (elemDelim = process.env.REBEM_ELEM_DELIM || '__',
+         modDelim = process.env.REBEM_MOD_DELIM || '_') =>
     (css) => {
         css.walkRules((rule) => {
             rule.selector = rule.selector


### PR DESCRIPTION
As follows: 

`require('rebem-css')("--")`
`require('rebem-css')("--", "*")`
`require('rebem-css')` 

in `postcss.config.js`:

```
module.exports = {
  plugins: [
    require('rebem-css')("--", "*")
  ]
};
```
